### PR TITLE
[MySQL] Add "on duplicate key update" support for BulkInsert

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -103,6 +103,11 @@ subprojects { project ->
                             name = "Ray Eldath"
                             email = "ray.eldath@outlook.com"
                         }
+                        developer {
+                            id = "hangingman"
+                            name = "hiroyuki.nagata"
+                            email = "idiotpanzer@gmail.com"
+                        }
                     }
                     scm {
                         url = "https://github.com/vincentlauvlwj/Ktorm.git"

--- a/ktorm-core/src/main/kotlin/me/liuwj/ktorm/dsl/Dml.kt
+++ b/ktorm-core/src/main/kotlin/me/liuwj/ktorm/dsl/Dml.kt
@@ -464,6 +464,16 @@ open class AssignmentsBuilder(private val assignments: MutableList<ColumnAssignm
         this to wrapArgument(argument)
     }
 
+    infix fun <C : Any> Column<C>.values(expr: ColumnDeclaring<C>) {
+        // values(column)
+        val values = FunctionExpression(
+            functionName = "values",
+            arguments = listOf(expr.asExpression()),
+            sqlType = expr.sqlType
+        )
+        assignments += ColumnAssignmentExpression(asExpression(), values)
+    }
+
     /**
      * Assign the current column to a specific value.
      *

--- a/ktorm-core/src/main/kotlin/me/liuwj/ktorm/dsl/Dml.kt
+++ b/ktorm-core/src/main/kotlin/me/liuwj/ktorm/dsl/Dml.kt
@@ -465,19 +465,6 @@ open class AssignmentsBuilder(private val assignments: MutableList<ColumnAssignm
     }
 
     /**
-     * Use VALUES() function in a ON DUPLICATE KEY UPDATE clause.
-     */
-    infix fun <C : Any> Column<C>.values(expr: ColumnDeclaring<C>) {
-        // values(column)
-        val values = FunctionExpression(
-            functionName = "values",
-            arguments = listOf(expr.asExpression()),
-            sqlType = expr.sqlType
-        )
-        assignments += ColumnAssignmentExpression(asExpression(), values)
-    }
-
-    /**
      * Assign the current column to a specific value.
      *
      * Note that this function accepts an argument type `Any?`, that's because it is designed to avoid

--- a/ktorm-core/src/main/kotlin/me/liuwj/ktorm/dsl/Dml.kt
+++ b/ktorm-core/src/main/kotlin/me/liuwj/ktorm/dsl/Dml.kt
@@ -464,6 +464,9 @@ open class AssignmentsBuilder(private val assignments: MutableList<ColumnAssignm
         this to wrapArgument(argument)
     }
 
+    /**
+     * Use VALUES() function in a ON DUPLICATE KEY UPDATE clause.
+     */
     infix fun <C : Any> Column<C>.values(expr: ColumnDeclaring<C>) {
         // values(column)
         val values = FunctionExpression(

--- a/ktorm-support-mysql/src/main/kotlin/me/liuwj/ktorm/support/mysql/MySqlDialect.kt
+++ b/ktorm-support-mysql/src/main/kotlin/me/liuwj/ktorm/support/mysql/MySqlDialect.kt
@@ -108,7 +108,7 @@ open class MySqlFormatter(database: Database, beautifySql: Boolean, indentSize: 
 
         if (expr.updateAssignments.isNotEmpty()) {
             write("on duplicate key update ")
-            visitColumnAssignmentsWithValues(expr.updateAssignments)
+            visitColumnAssignments(expr.updateAssignments)
         }
 
         return expr
@@ -119,21 +119,6 @@ open class MySqlFormatter(database: Database, beautifySql: Boolean, indentSize: 
         visitExpressionList(assignments.map { it.expression as ArgumentExpression })
         removeLastBlank()
         write(") ")
-    }
-
-    private fun visitColumnAssignmentsWithValues(original: ArrayList<ColumnAssignmentExpression<*>>):
-            List<ColumnAssignmentExpression<*>> {
-        for ((i, assignment) in original.withIndex()) {
-            if (i > 0) {
-                removeLastBlank()
-                write(", ")
-            }
-            visitColumn(assignment.column)
-            write("= ")
-            visit(assignment.expression)
-        }
-
-        return original
     }
 
     protected open fun visitNaturalJoin(expr: NaturalJoinExpression): NaturalJoinExpression {
@@ -211,8 +196,9 @@ open class MySqlExpressionVisitor : SqlExpressionVisitor() {
         }
     }
 
-    protected open fun visitBulkInsertAssignments(assignments: List<List<ColumnAssignmentExpression<*>>>):
-            List<List<ColumnAssignmentExpression<*>>> {
+    protected open fun visitBulkInsertAssignments(
+        assignments: List<List<ColumnAssignmentExpression<*>>>
+    ): List<List<ColumnAssignmentExpression<*>>> {
         val result = ArrayList<List<ColumnAssignmentExpression<*>>>()
         var changed = false
 

--- a/ktorm-support-mysql/src/main/kotlin/me/liuwj/ktorm/support/mysql/MySqlDialect.kt
+++ b/ktorm-support-mysql/src/main/kotlin/me/liuwj/ktorm/support/mysql/MySqlDialect.kt
@@ -106,6 +106,11 @@ open class MySqlFormatter(database: Database, beautifySql: Boolean, indentSize: 
             writeValues(assignments)
         }
 
+        if (expr.updateAssignments.isNotEmpty()) {
+            write("on duplicate key update ")
+            visitColumnAssignmentsWithValues(expr.updateAssignments)
+        }
+
         return expr
     }
 
@@ -114,6 +119,22 @@ open class MySqlFormatter(database: Database, beautifySql: Boolean, indentSize: 
         visitExpressionList(assignments.map { it.expression as ArgumentExpression })
         removeLastBlank()
         write(") ")
+    }
+
+    private fun visitColumnAssignmentsWithValues(
+            original: ArrayList<ColumnAssignmentExpression<*>>
+    ): List<ColumnAssignmentExpression<*>> {
+        for ((i, assignment) in original.withIndex()) {
+            if (i > 0) {
+                removeLastBlank()
+                write(", ")
+            }
+            visitColumn(assignment.column)
+            write("= ")
+            visit(assignment.expression)
+        }
+
+        return original
     }
 
     protected open fun visitNaturalJoin(expr: NaturalJoinExpression): NaturalJoinExpression {

--- a/ktorm-support-mysql/src/main/kotlin/me/liuwj/ktorm/support/mysql/MySqlDialect.kt
+++ b/ktorm-support-mysql/src/main/kotlin/me/liuwj/ktorm/support/mysql/MySqlDialect.kt
@@ -121,9 +121,8 @@ open class MySqlFormatter(database: Database, beautifySql: Boolean, indentSize: 
         write(") ")
     }
 
-    private fun visitColumnAssignmentsWithValues(
-            original: ArrayList<ColumnAssignmentExpression<*>>
-    ): List<ColumnAssignmentExpression<*>> {
+    private fun visitColumnAssignmentsWithValues(original: ArrayList<ColumnAssignmentExpression<*>>):
+            List<ColumnAssignmentExpression<*>> {
         for ((i, assignment) in original.withIndex()) {
             if (i > 0) {
                 removeLastBlank()
@@ -212,9 +211,8 @@ open class MySqlExpressionVisitor : SqlExpressionVisitor() {
         }
     }
 
-    protected open fun visitBulkInsertAssignments(
-        assignments: List<List<ColumnAssignmentExpression<*>>>
-    ): List<List<ColumnAssignmentExpression<*>>> {
+    protected open fun visitBulkInsertAssignments(assignments: List<List<ColumnAssignmentExpression<*>>>):
+            List<List<ColumnAssignmentExpression<*>>> {
         val result = ArrayList<List<ColumnAssignmentExpression<*>>>()
         var changed = false
 

--- a/ktorm-support-mysql/src/test/kotlin/me/liuwj/ktorm/support/mysql/MySqlTest.kt
+++ b/ktorm-support-mysql/src/test/kotlin/me/liuwj/ktorm/support/mysql/MySqlTest.kt
@@ -67,7 +67,7 @@ class MySqlTest : BaseTest() {
             }
             onDuplicateKey {
                 it.name to it.name
-                it.job values it.job
+                it.job to values(it.job)
             }
         }
 

--- a/ktorm-support-mysql/src/test/kotlin/me/liuwj/ktorm/support/mysql/MySqlTest.kt
+++ b/ktorm-support-mysql/src/test/kotlin/me/liuwj/ktorm/support/mysql/MySqlTest.kt
@@ -65,6 +65,10 @@ class MySqlTest : BaseTest() {
                 it.salary to 100
                 it.departmentId to 2
             }
+            onDuplicateKey {
+                it.name to it.name
+                it.job values it.job
+            }
         }
 
         assert(database.sequenceOf(Employees).count() == 6)


### PR DESCRIPTION
resolve #127

## Whats' this PR do ?
- Implements MySQL  bulk inserts with on duplicate key update

### use-case

* This Kotlin DSL
```kotlin
        database.bulkInsert(Employees) {
            item {
                it.name to "jerry"
                it.job to "trainee"
                it.managerId to 1
                it.hireDate to LocalDate.now()
                it.salary to 50
                it.departmentId to 1
            }
            item {
                it.name to "linda"
                it.job to "assistant"
                it.managerId to 3
                it.hireDate to LocalDate.now()
                it.salary to 100
                it.departmentId to 2
            }
            onDuplicateKey {
                it.name to it.name
                it.job values it.job
            }
        }
```
*  will generate SQL like following
```sql
insert into
    t_employee (name, job, manager_id, hire_date, salary, department_id)

values (?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?)

on duplicate key update
  t_employee.name = t_employee.name,
  t_employee.job = values(t_employee.job) 
```

- Especially I would like to use `ON DUPLICATE KEY UPDATE col=VALUES(expr)`
- I think this will compare data to insert and data hold by the table, then execute insertion if there is any difference between those data

I read this document to implement this feature: [INSERT ON DUPLICATE KEY UPDATE](https://mariadb.com/kb/en/insert-on-duplicate-key-update/)

## Solution

- Added an another block `onDuplicateKey` in `BulkInsertStatementBuilder` 
  - I referred `insertOrUpdate` code for this task
- Added `values` to use this DSL in `AssignmentsBuilder`