### PR TITLE
avoid unnecessary flushing when set property to same value

### DIFF
--- a/ktorm-core/src/main/kotlin/org/ktorm/entity/EntityImplementation.kt
+++ b/ktorm-core/src/main/kotlin/org/ktorm/entity/EntityImplementation.kt
@@ -152,7 +152,7 @@ internal class EntityImplementation(
         }
 
         // Save property changes and original values.
-        if (name !in changedProperties) {
+        if (name !in changedProperties && value != values[name]) {
             changedProperties[name] = values[name]
         }
 


### PR DESCRIPTION
Assuming we are doing some query-and-update actions like below
```kotlin
val employee = database.employees.find { it.id eq 5 } ?: return
employee.salary = 100
employee.flushChanges()
```
What will happen if the employee's salary is already 100?
That is, an updating expression will be generated and executed, while affect rows' number is zero.
```shell
mysql> update t_employee set salary = 100 where id = 1;
Query OK, 0 rows affected (0.00 sec)
Rows matched: 1  Changed: 0  Warnings: 0
```

However, such expression is unnecessary to be executed, we can compare value with previous one to avoid executing it.

As always, thanks for reading and maintaining the library!