### PR TITLE
add support for subqueries in select expression

### DIFF
--- a/buildSrc/src/main/kotlin/ktorm.publish.gradle.kts
+++ b/buildSrc/src/main/kotlin/ktorm.publish.gradle.kts
@@ -164,6 +164,11 @@ publishing {
                         name.set("hc224")
                         email.set("hc224@pm.me")
                     }
+                    developer {
+                        id.set("sasa-b")
+                        name.set("Sasa Blagojevic")
+                        email.set("sasa.blagojevic@mail.com")
+                    }
                 }
             }
         }

--- a/ktorm-core/src/main/kotlin/org/ktorm/dsl/Query.kt
+++ b/ktorm-core/src/main/kotlin/org/ktorm/dsl/Query.kt
@@ -22,6 +22,7 @@ import org.ktorm.expression.*
 import org.ktorm.schema.BooleanSqlType
 import org.ktorm.schema.Column
 import org.ktorm.schema.ColumnDeclaring
+import org.ktorm.schema.SqlType
 import java.sql.ResultSet
 
 /**
@@ -445,6 +446,20 @@ public fun Query.union(right: Query): Query {
  */
 public fun Query.unionAll(right: Query): Query {
     return this.withExpression(UnionExpression(left = expression, right = right.expression, isUnionAll = true))
+}
+
+/**
+ * Wrap this query as a column [ColumnSubqueryExpression].
+ */
+public fun <T: Any> Query.asSubquery(sqlType: SqlType<T>): ColumnSubqueryExpression<T> {
+    return ColumnSubqueryExpression(expression, sqlType = sqlType, isLeafNode = false)
+}
+
+/**
+ * Wrap this query as a column [ColumnDeclaringExpression].
+ */
+public fun <T: Any> Query.asSubquery(sqlType: SqlType<T>, label: String): ColumnDeclaringExpression<T> {
+    return ColumnSubqueryExpression(expression, sqlType = sqlType, isLeafNode = false).aliased(label)
 }
 
 /**

--- a/ktorm-core/src/main/kotlin/org/ktorm/expression/SqlExpressionVisitor.kt
+++ b/ktorm-core/src/main/kotlin/org/ktorm/expression/SqlExpressionVisitor.kt
@@ -68,6 +68,7 @@ public interface SqlExpressionVisitor {
         val result = when (expr) {
             is ColumnExpression -> visitColumn(expr)
             is ColumnDeclaringExpression -> visitColumnDeclaring(expr)
+            is ColumnSubqueryExpression -> visitColumnSubquery(expr)
             is UnaryExpression -> visitUnary(expr)
             is BinaryExpression -> visitBinary(expr)
             is ArgumentExpression -> visitArgument(expr)
@@ -283,6 +284,16 @@ public interface SqlExpressionVisitor {
             return expr
         } else {
             return expr.copy(expression = expression)
+        }
+    }
+
+    public fun <T: Any> visitColumnSubquery(expr: ColumnSubqueryExpression<T>): ColumnSubqueryExpression<T> {
+        val query = visitQuery(expr.query)
+
+        if (query === expr.query) {
+            return expr
+        } else {
+            return expr.copy(query = query)
         }
     }
 

--- a/ktorm-core/src/main/kotlin/org/ktorm/expression/SqlExpressions.kt
+++ b/ktorm-core/src/main/kotlin/org/ktorm/expression/SqlExpressions.kt
@@ -300,7 +300,7 @@ public data class ColumnDeclaringExpression<T : Any>(
 /**
  * Column subquery expression, represents a subquery as a selected column in a [SelectExpression].
  *
- * For example, `select a.name, (select count(*) from dual) as total_names from dual`, `(select count(*) from dual) as total_names` is the subquery as a selected column.
+ * For example, `select a.name, (select count(*) from b where b.a_id = a.id) as total_names from a`, `(select count(*) from b where b.a_id = a.id) as total_names` is the subquery as a selected column.
  *
  */
 public data class ColumnSubqueryExpression<T: Any>(

--- a/ktorm-core/src/main/kotlin/org/ktorm/expression/SqlExpressions.kt
+++ b/ktorm-core/src/main/kotlin/org/ktorm/expression/SqlExpressions.kt
@@ -298,6 +298,19 @@ public data class ColumnDeclaringExpression<T : Any>(
 }
 
 /**
+ * Column subquery expression, represents a subquery as a selected column in a [SelectExpression].
+ *
+ * For example, `select a.name, (select count(*) from dual) as total_names from dual`, `(select count(*) from dual) as total_names` is the subquery as a selected column.
+ *
+ */
+public data class ColumnSubqueryExpression<T: Any>(
+    val query: QueryExpression,
+    override val sqlType: SqlType<T>,
+    override val isLeafNode: Boolean = false,
+    override val extraProperties: Map<String, Any> = emptyMap()
+) : ScalarExpression<T>()
+
+/**
  * Column assignment expression, represents a column assignment for insert or update statements.
  *
  * @property column the left value of the assignment.

--- a/ktorm-core/src/main/kotlin/org/ktorm/expression/SqlFormatter.kt
+++ b/ktorm-core/src/main/kotlin/org/ktorm/expression/SqlFormatter.kt
@@ -216,6 +216,16 @@ public abstract class SqlFormatter(
         return expr
     }
 
+    override fun <T : Any> visitColumnSubquery(expr: ColumnSubqueryExpression<T>): ColumnSubqueryExpression<T> {
+        write("(")
+        newLine(Indentation.INNER)
+        visit(expr.query)
+        removeLastBlank()
+        newLine(Indentation.OUTER)
+        write(") ")
+        return expr
+    }
+
     override fun visitSelect(expr: SelectExpression): SelectExpression {
         writeKeyword("select ")
         if (expr.isDistinct) {

--- a/ktorm-core/src/test/kotlin/org/ktorm/dsl/QueryTest.kt
+++ b/ktorm-core/src/test/kotlin/org/ktorm/dsl/QueryTest.kt
@@ -2,7 +2,9 @@ package org.ktorm.dsl
 
 import org.junit.Test
 import org.ktorm.BaseTest
+import org.ktorm.expression.ColumnSubqueryExpression
 import org.ktorm.expression.ScalarExpression
+import org.ktorm.schema.LongSqlType
 import org.ktorm.schema.TextSqlType
 import java.sql.Clob
 import kotlin.random.Random
@@ -243,6 +245,42 @@ class QueryTest : BaseTest() {
             .where { Employees.departmentId inList departmentIds }
 
         assert(query.rowSet.size() == 4)
+
+        println(query.sql)
+    }
+
+    @Test
+    fun testColumnCorrelatedSubquery() {
+        val employeesCount = database.from(Employees)
+            .select(count())
+            .where { Departments.id eq Employees.departmentId }
+            .asSubquery(LongSqlType)
+
+        val query = database
+            .from(Departments)
+            .select(Departments.id, employeesCount)
+
+        assert(query.rowSet.size() == 2)
+        val results = query.joinToString { row -> row.getLong(2).toString() }
+        assertEquals("2, 2", results)
+
+        println(query.sql)
+    }
+
+    @Test
+    fun testColumnCorrelatedSubqueryWithAlias() {
+        val employeesInDepartmentCount = database.from(Employees)
+            .select(count())
+            .where { Departments.id eq Employees.departmentId }
+            .asSubquery(LongSqlType, "employee_count")
+
+        val query = database
+            .from(Departments)
+            .select(Departments.columns + employeesInDepartmentCount)
+
+        assert(query.rowSet.size() == 2)
+        val results = query.joinToString { row -> row.getLong("employee_count").toString() }
+        assertEquals("2, 2", results)
 
         println(query.sql)
     }


### PR DESCRIPTION
This is a common use case when we want to have a column derived from a subquery, most often it is a correlated subquery https://dev.mysql.com/doc/refman/8.4/en/correlated-subqueries.html.
 
```SQL
SELECT 
departments.id,
depratments.name,
(SELECT COUNT(*) FROM employees WHERE employees.department_id = departments.id) AS total_employess 
FROM departments;
``` 

P.S. If there is interest, I can raise a follow-up PR to add support for subqueries in where statements. 

This is kinda already supported with the `InListExpression` and `ExistsExpression`, but that only covers two use cases, we could add support for all the other operators like `>`, `<`, `=`, `>=`, `<=` etc. It's fairly common to have  aggregate subqueries in where conditions.